### PR TITLE
Correctly match boolean and null values

### DIFF
--- a/lib/assert_json/assert_json.rb
+++ b/lib/assert_json/assert_json.rb
@@ -45,7 +45,8 @@ module AssertJson
       case token
       when Hash
         raise_error("element #{arg} not found") unless token.keys.include?(arg)
-        if second_arg = args.shift
+        unless args.empty?
+          second_arg = args.shift
           case second_arg
           when Regexp
             raise_error("element #{token[arg].inspect} does not match #{second_arg.inspect}") if second_arg !~ token[arg]

--- a/test/assert_json_new_dsl_test.rb
+++ b/test/assert_json_new_dsl_test.rb
@@ -299,4 +299,49 @@ class AssertJsonNewDslTest < Test::Unit::TestCase
       end
     end
   end
+
+  def test_boolean
+    assert_json '{"key": true}' do
+      has 'key', true
+    end
+    assert_json '{"key": false}' do
+      has 'key', false
+    end
+  end
+
+  def test_boolean_crosscheck
+    assert_raises(MiniTest::Assertion) do
+      assert_json '{"key": false}' do
+        has 'key', true
+      end
+    end
+    assert_raises(MiniTest::Assertion) do
+      assert_json '{"key": true}' do
+        has 'key', false
+      end
+    end
+  end
+
+  def test_null
+    assert_json '{"key": null}' do
+      has 'key', nil
+    end
+  end
+
+  def test_not_null
+    assert_raises(MiniTest::Assertion) do
+      assert_json '{"key": 1}' do
+        has 'key', nil
+      end
+    end
+  end
+
+  def test_null_crosscheck
+    assert_raises(MiniTest::Assertion) do
+      assert_json '{"key": null}' do
+        has_not 'key'
+      end
+    end
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'rubygems'
+require 'minitest'
 require 'test/unit'
 require 'active_support'
 


### PR DESCRIPTION
Here is the fix which correctly asserts with:

```
has "key", false
has "key", nil
```

Previously the above would pass a JSON with any value for the key.
