### PR TITLE
Allow Ruby symbols as keys and values

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ class MyActionTest < ActionController::TestCase
 
   def test_my_action
     get :my_action, :format => 'json'
-    # => @response.body= '{"key":[{"inner_key1":"value1"},{"inner_key2":"value2"}]}'
+    # => @response.body= '{"key":[{"inner_key1":"value1"},{"inner_key2":"value2"}, {'special-key': null}]}'
 
     assert_json(@response.body) do
-      has 'key' do
-        has 'inner_key1', 'value1'
-        has 'inner_key2', /lue2/
+      has :key do
+        has :inner_key1, 'value1'
+        has :inner_key2, /lue2/
       end
-      has_not 'key_not_included'
+      has 'special-key', nil
+      has_not :key_not_included
     end
   end
 
@@ -45,9 +46,9 @@ use `item(i)` to select the item to test, like this
 ```ruby
 assert_json '[{"id":1, "key":"test", "name":"test"}, {"id":2, "key":"test", "name":"test"}, {"id":3, "key":"test", "name":"test"}]' do
   item 0 do
-    has 'id', 1
-    has 'key', 'test'
-    has 'name', 'test'
+    has :id, 1
+    has :key, 'test'
+    has :name, 'test'
   end
   item 2 do
     has 'id', 3

--- a/lib/assert_json/assert_json.rb
+++ b/lib/assert_json/assert_json.rb
@@ -44,14 +44,18 @@ module AssertJson
               end
       case token
       when Hash
+        arg = arg.to_s
         raise_error("element #{arg} not found") unless token.keys.include?(arg)
         unless args.empty?
           second_arg = args.shift
+          gen_error = lambda {raise_error("element #{token[arg].inspect} does not match #{second_arg.inspect}")}
           case second_arg
           when Regexp
-            raise_error("element #{token[arg].inspect} does not match #{second_arg.inspect}") if second_arg !~ token[arg]
+            gen_error.call if second_arg !~ token[arg]
+          when Symbol
+            gen_error.call if second_arg.to_s != token[arg]
           else
-            raise_error("element #{token[arg].inspect} does not match #{second_arg.inspect}") if second_arg != token[arg]
+            gen_error.call if second_arg != token[arg]
           end
         end
       when Array
@@ -61,7 +65,7 @@ module AssertJson
         when Regexp
           raise_error("element #{arg.inspect} not found") if token !~ arg
         else
-          raise_error("element #{arg.inspect} not found") if token != arg
+          raise_error("element #{arg.inspect} not found") if token != arg.to_s
         end
       when NilClass
         raise_error("no element left")
@@ -86,9 +90,9 @@ module AssertJson
       token = @decoded_json
       case token
       when Array
-        raise_error("element #{arg} found, but not expected") if token.include?(arg)
+        raise_error("element #{arg} found, but not expected") if token.include?(arg.to_s)
       else
-        raise_error("element #{arg} found, but not expected") if token.keys.include?(arg)
+        raise_error("element #{arg} found, but not expected") if token.keys.include?(arg.to_s)
       end
     end
     alias has_not not_element

--- a/test/assert_json_new_dsl_test.rb
+++ b/test/assert_json_new_dsl_test.rb
@@ -344,4 +344,66 @@ class AssertJsonNewDslTest < Test::Unit::TestCase
     end
   end
 
+  def test_symbol_as_a_value
+    assert_json '{"key": "text"}' do
+      has :key, :text
+    end
+    assert_raises(MiniTest::Assertion) do
+      assert_json '{"key": "badtext"}' do
+        has :key, :text
+      end
+    end
+  end
+
+  def test_symbol_as_a_key
+    assert_json '{"sym": true, "text": "1"}' do
+      has :sym, true
+      has :text, /\d+/
+      has_not :bad_sym
+    end
+    assert_json '{"sym": false, "text": "2", "topkey": {"subkey": "value1"}}' do
+      has :sym, false
+      has :text, /\d+/
+      has_not :bad_sym
+      has :topkey do
+        has :subkey, :value1
+      end
+    end
+  end
+
+  def test_symbol_as_string_value
+    assert_json '{"topkey": {"subkey": "value1"}}' do
+      has :topkey do
+        has :subkey do
+          has :value1
+        end
+      end
+    end
+  end
+
+
+  def test_symbol_as_a_key_crossheck
+    assert_raises(MiniTest::Assertion) do
+      assert_json '{"text": "1"}' do
+        has :sym, true  #this should fail
+        has :text, /\d+/
+        has_not :bad_sym
+      end
+    end
+
+    assert_raises(MiniTest::Assertion) do
+      assert_json '{"sym": false, "text": "abc"}' do
+        has :sym, false
+        has :text, /\d+/   #this should fail
+        has_not :bad_sym
+      end
+    end
+
+    assert_raises(MiniTest::Assertion) do
+      assert_json '{"sym": false}' do
+        has_not :sym
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This PR makes `assert_json` more Ruby-way, so symbols can be used as keys and even values in matchers.
