### PR TITLE
Support numbers in json.

### DIFF
--- a/lib/assert_json/assert_json.rb
+++ b/lib/assert_json/assert_json.rb
@@ -51,7 +51,7 @@ module AssertJson
           gen_error = lambda {raise_error("element #{token[arg].inspect} does not match #{second_arg.inspect}")}
           case second_arg
           when Regexp
-            gen_error.call if second_arg !~ token[arg]
+            gen_error.call if second_arg !~ token[arg].to_s
           when Symbol
             gen_error.call if second_arg.to_s != token[arg]
           else

--- a/test/assert_json_new_dsl_test.rb
+++ b/test/assert_json_new_dsl_test.rb
@@ -406,4 +406,10 @@ class AssertJsonNewDslTest < Minitest::Test
     end
   end
 
+  def test_regex_with_number
+    assert_json '{"number": 1}' do
+      has :number, /^\d+$/
+    end
+  end
+
 end


### PR DESCRIPTION
Moin Thorsten,

I hope all is good in HH :)?!

I'm using your great gem to test my JSON responses. Today I noticed that using regexes together with plain numbers (vs. quoted ones "1") is not working (tested on 2.1.2p95). It throws a TypeError:

`TypeError: no implicit conversion of Fixnum into String`

I have fixed that issue and added a test for it.

Cheers,
plu
