### PR TITLE
has_only: enforce a fixed sets of JSON object properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,26 @@ assert_json '[{"id":1, "key":"test", "name":"test"}, {"id":2, "key":"test", "nam
 end
 ```
 
+To test that objects have the declared set of properties and nothing more,
+include `has_only` at any level, like this
+
+```ruby
+assert_json '[{"id":1, "key":"test", "name":"test"}, {"id":2, "key":"test", "name":"test"}, {"id":3, "key":"test", "name":"test"}]' do
+  has_only
+  item 0 do
+    has :id, 1
+    has :key, 'test'
+    has :name, 'test'
+  end
+  item 1 do
+    has 'id', 2
+    has 'key', 'test'
+  end
+end
+
+# Failure: element 1 has unexpected keys: name
+```
+
 
 ## Changelog ##
 

--- a/test/assert_json_has_only_test.rb
+++ b/test/assert_json_has_only_test.rb
@@ -1,0 +1,94 @@
+require_relative './test_helper'
+
+class AssertJsonHasNoUnexpectedKeysTest < Minitest::Test
+  include AssertJson
+
+  def test_on_root_object
+    assert_json '{"keyA":"value","keyB":"value"}' do
+      has_only
+      has 'keyA'
+      has 'keyB'
+    end
+  end
+
+  def test_on_root_object_failure
+    err = assert_raises(MiniTest::Assertion) do
+      assert_json '{"keyA":"value","keyB":"value"}' do
+        has_only
+        has 'keyA', 'value'
+      end
+    end
+    assert_equal 'element root has unexpected keys: keyB', err.message
+  end
+
+  def test_on_root_object_with_sub_object
+    assert_json '{"keyA":{"subKeyA":"value","subKeyB":"value"},"keyB":"value"}' do
+      has_only
+      has 'keyA' do
+        has 'subKeyA'
+        has 'subKeyB'
+      end
+      has 'keyB'
+    end
+  end
+
+  def test_on_root_object_with_sub_object_failure
+    err = assert_raises(MiniTest::Assertion) do
+      assert_json '{"keyA":{"subKeyA":"value","subKeyB":"value"},"keyB":"value"}' do
+        has_only
+        has 'keyA' do
+          has 'subKeyA'
+          has 'subKeyB'
+        end
+      end
+    end
+    assert_equal 'element root has unexpected keys: keyB', err.message
+  end
+
+  def test_on_sub_object
+    assert_json '{"keyA":{"subKeyA":"value","subKeyB":"value"},"keyB":"value"}' do
+      has 'keyA' do
+        has_only
+        has 'subKeyA'
+        has 'subKeyB'
+      end
+    end
+  end
+
+  def test_on_sub_object_failure
+    err = assert_raises(MiniTest::Assertion) do
+      assert_json '{"keyA":{"subKeyA":"value","subKeyB":"value"},"keyB":"value"}' do
+        has 'keyA' do
+          has_only
+          has 'subKeyA'
+        end
+      end
+    end
+    assert_equal 'element keyA has unexpected keys: subKeyB', err.message
+  end
+
+  def test_on_root_array_of_objects
+    assert_json '[{"id":1, "key":"test", "name":"test"}, {"id":2, "key":"test", "name":"test"}, {"id":3, "key":"test", "name":"test"}]' do
+      has_only
+      item 0 do
+        has :id, 1
+        has :key, 'test'
+        has :name, 'test'
+      end
+    end
+  end
+
+  def test_on_root_array_of_objects_failure
+    err = assert_raises(MiniTest::Assertion) do
+      assert_json '[{"id":1, "key":"test", "name":"test"}, {"id":2, "key":"test", "name":"test"}, {"id":3, "key":"test", "name":"test"}]' do
+        has_only
+        item 0 do
+          has :id, 1
+          has :key, 'test'
+        end
+      end
+    end
+    assert_equal 'element 0 has unexpected keys: name', err.message
+  end
+
+end


### PR DESCRIPTION
I sometimes need to guarantee nothing gets accidentally added to a JSON response. I can't predict what might get accidentally added with `has_not`, so I've added a `has_only` method, which will cause any properties that have not been tested with `has` to throw an exception.

This applies to the object you add the call to, as well as any nested objects.

```ruby
assert_json '[{"id":1, "key":"test", "name":"test"}, {"id":2, "key":"test", "name":"test"}, {"id":3, "key":"test", "name":"test"}]' do
  has_only
  item 0 do
    has :id, 1
    has :key, 'test'
    has :name, 'test'
  end
  item 1 do
    has 'id', 2
    has 'key', 'test'
  end
end

# Failure: element 1 has unexpected keys: name
```
