### PR TITLE
Compare serialized values instead of values

### DIFF
--- a/lib/assert_json/assert_json.rb
+++ b/lib/assert_json/assert_json.rb
@@ -84,11 +84,11 @@ module AssertJson
           when Symbol
             gen_error.call if second_arg.to_s != token[arg]
           else
-            gen_error.call if second_arg != token[arg]
+            gen_error.call if second_arg.to_json != token[arg].to_json
           end
         end
       when Array
-        raise_error("element #{arg} not found") if !block_given? && token != arg
+        raise_error("element #{arg} not found") if !block_given? && token.to_json != arg.to_json
       when String
         case arg
         when Regexp

--- a/test/assert_json_test.rb
+++ b/test/assert_json_test.rb
@@ -32,6 +32,38 @@ class AssertJsonTest < Minitest::Test
     end
   end
 
+  context "numbers" do
+    should "test_integer" do
+      assert_json '{"some":1}' do |json|
+        json.element "some", 1
+      end
+
+      assert_json '{"some":-1}' do |json|
+        json.element "some", -1
+      end
+    end
+
+    should "test_float" do
+      assert_json '{"some":1.234}' do |json|
+        json.element "some", 1.234
+      end
+    end
+
+    should "test_bigdecimal" do
+      require 'bigdecimal'
+
+      assert_raises(MiniTest::Assertion) do
+        assert_json '{"some":1.234}' do |json|
+          json.element "some", BigDecimal.new('1.234')
+        end
+      end
+
+      assert_json '{"some":"1.234"}' do |json|
+        json.element "some", BigDecimal.new('1.234')
+      end
+    end
+  end
+
   context "hashes" do
     should "test_single_hash" do
       assert_json '{"key":"value"}' do |json|


### PR DESCRIPTION
This fixes asserting values that would be equal when using == but
wouldn't serialize the same. A good example is BigDecimal that serialize to
string in most json encoders.
