### PR TITLE
Remove Assertions#flunk reference

### DIFF
--- a/lib/assert_json/assert_json.rb
+++ b/lib/assert_json/assert_json.rb
@@ -99,7 +99,11 @@ module AssertJson
       when NilClass
         raise_error("no element left")
       else
-        flunk
+        raise ArgumentError,
+          format(
+            "can't compare %s(%s) with %s(%s)",
+            token, token.class, arg, arg.class
+          )
       end
 
       @expected_keys.push arg


### PR DESCRIPTION
Removes flunk as it got deprecated since 1.9 and removed in later versions.
